### PR TITLE
use YAML.safe_load() instead of YAML.load() due to deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
     - "2.6"
     - "2.7"
+    - "3.4"
+    - "3.5"
 
 env:
     global:
@@ -15,7 +17,7 @@ install:
     - make -C beanstalkd-1.10/
     - mv beanstalkd-1.10/beanstalkd .
     # Install Python dependencies.
-    - pip install -r .travis-requirements.txt --use-mirrors
+    - pip install -r .travis-requirements.txt
 
 script: nosetests -c .nose.cfg
 

--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -61,25 +61,29 @@ receive a job. If such a `reserve` times out, it will return `None`:
 If you use a timeout of 0, `reserve` will immediately return either a job or
 `None`.
 
-Note that beanstalkc requires job bodies to be strings, conversion to/from
-strings is left up to you:
+Note that beanstalkc requires job bodies to be strings or bytes objects:
 
     >>> beanstalk.put(42)
     Traceback (most recent call last):
     ...
-    AssertionError: Job body must be a str instance
+    ValueError: Job body must be a str or bytes instance
 
 There is no restriction on what characters you can put in a job body, so they
 can be used to hold arbitrary binary data:
 
-    >>> _ = beanstalk.put('\x00\x01\xfe\xff')
-    >>> job = beanstalk.reserve() ; print(repr(job.body)) ; job.delete()
+    >>> beanstalk_binary = beanstalkc.Connection(host='localhost', port=14711, encoding=None)
+    >>> _ = beanstalk.put(b'\x00\x01\xfe\xff')
+    >>> job = beanstalk_binary.reserve() ; print(repr(job.body).replace('b','')) ; job.delete()
     '\x00\x01\xfe\xff'
 
-If you want to send images, just `put` the image data as a string. If you want
-to send Unicode text, just use `unicode.encode` to convert it to a string with
-some encoding.
-
+When using python 2, bytes and string objects can be used for input
+interchangably, and reserve will return string objects. Because python 3 is
+stricter when it comes to encodings, the rules are slightly different there and
+you you can specify an encoding to be used for job bodies. This encoding
+defaults to your system's default encoding and can be set to `None` if you do
+not want beanstalkc to try to encode/decode job bodies. In that case, `put`
+will only accept bytes objects and `reserve` and the `peek` functions will
+return bytes objects.
 
 Tube Management
 ---------------
@@ -214,7 +218,7 @@ the `Connection`'s `stats` method. We won't go into details here, but:
 
     >>> pprint(beanstalk.stats())                   # doctest: +ELLIPSIS
     {...
-     'current-connections': 1,
+     'current-connections': 2,
      'current-jobs-buried': 0,
      'current-jobs-delayed': 0,
      'current-jobs-ready': 0,

--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -70,9 +70,16 @@ strings is left up to you:
     AssertionError: Job body must be a str instance
 
 There is no restriction on what characters you can put in a job body, so they
-can be used to hold arbitrary binary data. If you want to send images, just
-`put` the image data as a string. If you want to send Unicode text, just use
-`unicode.encode` to convert it to a string with some encoding.
+can be used to hold arbitrary binary data:
+
+    >>> _ = beanstalk.put('\x00\x01\xfe\xff')
+    >>> job = beanstalk.reserve() ; print(repr(job.body)) ; job.delete()
+    '\x00\x01\xfe\xff'
+
+If you want to send images, just `put` the image data as a string. If you want
+to send Unicode text, just use `unicode.encode` to convert it to a string with
+some encoding.
+
 
 Tube Management
 ---------------
@@ -167,7 +174,7 @@ Statistical details for a job can only be retrieved during the job's lifecycle.
 So let's create another job:
 
     >>> beanstalk.put('ho?')
-    2
+    3
 
     >>> job = beanstalk.reserve()
 
@@ -177,7 +184,7 @@ Now we retrieve job-level statistics:
     >>> pprint(job.stats())                         # doctest: +ELLIPSIS
     {'age': 0,
      ...
-     'id': 2,
+     'id': 3,
      ...
      'state': 'reserved',
      ...
@@ -262,7 +269,7 @@ create a job with a delay. Such a job will only be available for reservation
 once this delay passes:
 
     >>> beanstalk.put('yes!', delay=1)
-    3
+    4
 
     >>> beanstalk.reserve(timeout=0) is None
     True
@@ -320,10 +327,10 @@ Inspecting Jobs
 
 Besides reserving jobs, a client can also "peek" at jobs. This allows to inspect
 jobs without modifying their state. If you know the `id` of a job you're
-interested, you can directly peek at the job. We still have job #3 hanging
+interested, you can directly peek at the job. We still have job #4 hanging
 around from our previous examples, so:
 
-    >>> job = beanstalk.peek(3)
+    >>> job = beanstalk.peek(4)
     >>> job.body
     'yes!'
 

--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -6,6 +6,7 @@ Say hello to your fellow travel companion, the beanstalkc client library for
 Python. You'll get to know each other fairly well during this trip, so better
 start off on a friendly note. And now, let's go!
 
+
 Getting Started
 ---------------
 
@@ -362,16 +363,14 @@ You can, though, delete a job that was not reserved by you:
 
 Finally, you can also peek into the special queues for jobs that are delayed:
 
-    >>> beanstalk.put('o tempores', delay=120)
-    4
+    >>> _ = beanstalk.put('o tempores', delay=120)
     >>> job = beanstalk.peek_delayed()
     >>> job.stats()['state']
     'delayed'
 
 ... or buried:
 
-    >>> beanstalk.put('o mores!')
-    5
+    >>> _ = beanstalk.put('o mores!')
     >>> job = beanstalk.reserve()
     >>> job.bury()
 

--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -186,9 +186,8 @@ If you try to access job stats after the job was deleted, you'll get a
 `CommandFailed` exception:
 
     >>> job.delete()
-    >>> job.stats()                                 # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
+    >>> job.stats()                         # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ...
     CommandFailed: ('stats-job', 'NOT_FOUND', [])
 
 Let's have a look at some numbers for the `'default'` tube:
@@ -357,9 +356,8 @@ requests on unreserved jobs are silently ignored:
 You can, though, delete a job that was not reserved by you:
 
     >>> job.delete()
-    >>> job.stats()                                 # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
+    >>> job.stats()                         # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ...
     CommandFailed: ('stats-job', 'NOT_FOUND', [])
 
 Finally, you can also peek into the special queues for jobs that are delayed:

--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -186,7 +186,7 @@ If you try to access job stats after the job was deleted, you'll get a
 `CommandFailed` exception:
 
     >>> job.delete()
-    >>> job.stats()                                 # doctest: +ELLIPSIS
+    >>> job.stats()                                 # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CommandFailed: ('stats-job', 'NOT_FOUND', [])
@@ -357,7 +357,7 @@ requests on unreserved jobs are silently ignored:
 You can, though, delete a job that was not reserved by you:
 
     >>> job.delete()
-    >>> job.stats()                                 # doctest: +ELLIPSIS
+    >>> job.stats()                                 # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CommandFailed: ('stats-job', 'NOT_FOUND', [])
@@ -390,9 +390,9 @@ Without job priorities, beanstalkd operates as a FIFO queue:
     >>> _ = beanstalk.put('1')
     >>> _ = beanstalk.put('2')
 
-    >>> job = beanstalk.reserve() ; print job.body ; job.delete()
+    >>> job = beanstalk.reserve() ; print(job.body) ; job.delete()
     1
-    >>> job = beanstalk.reserve() ; print job.body ; job.delete()
+    >>> job = beanstalk.reserve() ; print(job.body) ; job.delete()
     2
 
 If need arises, you can override this behaviour by giving different jobs
@@ -413,11 +413,11 @@ To create a job with a custom priority, use the keyword-argument `priority`:
     >>> _ = beanstalk.put('bar', priority=21)
     >>> _ = beanstalk.put('qux', priority=21)
 
-    >>> job = beanstalk.reserve() ; print job.body ; job.delete()
+    >>> job = beanstalk.reserve() ; print(job.body) ; job.delete()
     bar
-    >>> job = beanstalk.reserve() ; print job.body ; job.delete()
+    >>> job = beanstalk.reserve() ; print(job.body) ; job.delete()
     qux
-    >>> job = beanstalk.reserve() ; print job.body ; job.delete()
+    >>> job = beanstalk.reserve() ; print(job.body) ; job.delete()
     foo
 
 Note how `'bar'` and `'qux'` left the queue before `'foo'`, even though they

--- a/beanstalkc.py
+++ b/beanstalkc.py
@@ -21,6 +21,7 @@ __version__ = '0.4.0'
 
 import logging
 import socket
+import sys
 
 
 DEFAULT_HOST = 'localhost'
@@ -39,7 +40,8 @@ class SocketError(BeanstalkcException):
     def wrap(wrapped_function, *args, **kwargs):
         try:
             return wrapped_function(*args, **kwargs)
-        except socket.error, err:
+        except socket.error:
+            err = sys.exc_info()[1]
             raise SocketError(err)
 
 
@@ -128,7 +130,7 @@ class Connection(object):
     def _interact_peek(self, command):
         try:
             return self._interact_job(command, ['FOUND'], ['NOT_FOUND'], False)
-        except CommandFailed, (_, _status, _results):
+        except CommandFailed:
             return None
 
     # -- public interface --
@@ -153,7 +155,9 @@ class Connection(object):
             return self._interact_job(command,
                                       ['RESERVED'],
                                       ['DEADLINE_SOON', 'TIMED_OUT'])
-        except CommandFailed, (_, status, results):
+        except CommandFailed:
+            exc = sys.exc_info()[1]
+            _, status, results = exc.args
             if status == 'TIMED_OUT':
                 return None
             elif status == 'DEADLINE_SOON':

--- a/beanstalkc.py
+++ b/beanstalkc.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 """beanstalkc - A beanstalkd Client Library for Python"""
 
+import logging
+import socket
+import sys
+
+
 __license__ = '''
-Copyright (C) 2008-2014 Andreas Bolka
+Copyright (C) 2008-2015 Andreas Bolka
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,10 +23,6 @@ limitations under the License.
 '''
 
 __version__ = '0.4.0'
-
-import logging
-import socket
-import sys
 
 
 DEFAULT_HOST = 'localhost'

--- a/test/no-yaml.mkd
+++ b/test/no-yaml.mkd
@@ -12,7 +12,7 @@ Setup a connection that won't parse YAML:
 
 Observe that YAML is not parsed:
 
-    >>> isinstance(beanstalk.stats(), str)
+    >>> not isinstance(beanstalk.stats(), dict)
     True
 
 Note that while Job#release and Job#bury will still work, they won't

--- a/test/no-yaml.mkd
+++ b/test/no-yaml.mkd
@@ -21,13 +21,13 @@ automatically maintain the released/buried Job's priority:
     >>> jid = beanstalk.put('foo', priority=42)
 
     >>> job = beanstalk.reserve()
-    >>> print repr(job.stats())                     # doctest: +ELLIPSIS
+    >>> print(repr(job.stats()))                    # doctest: +ELLIPSIS
     '...pri: 42...'
 
     >>> job.release()               # Succeeds, but ...
 
     >>> job = beanstalk.reserve()   # ... may not do what you want.
-    >>> print repr(job.stats())                     # doctest: +ELLIPSIS
+    >>> print(repr(job.stats()))                    # doctest: +ELLIPSIS
     '...pri: 2147483648...'
 
     >>> job.delete()
@@ -37,12 +37,12 @@ Same for Job#bury:
     >>> jid = beanstalk.put('bar', priority=42)
 
     >>> job = beanstalk.reserve()
-    >>> print repr(job.stats())                     # doctest: +ELLIPSIS
+    >>> print(repr(job.stats()))                    # doctest: +ELLIPSIS
     '...pri: 42...'
 
     >>> job.bury()
 
-    >>> print repr(beanstalk.stats_job(jid))        # doctest: +ELLIPSIS
+    >>> print(repr(beanstalk.stats_job(jid)))       # doctest: +ELLIPSIS
     '...pri: 2147483648...'
 
 And that was that.


### PR DESCRIPTION
PyYAML's [yaml.load has been deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation). This patch addresses that by using `safe_load()` in place of `load()`