### PR TITLE
include LICENSE in tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
The Apache license requires that a copy of the license text be included whenever the software is distributed. But the tarballs published on PyPI currently do not contain a copy of the LICENSE file. This will make setuptools include them in future tarballs.